### PR TITLE
課金関連の基本的なテストケースを追加

### DIFF
--- a/app/Http/Controllers/SubscriptionController.php
+++ b/app/Http/Controllers/SubscriptionController.php
@@ -69,7 +69,6 @@ class SubscriptionController extends Controller
         }
 
         // 有効なプランが選択されていない場合は入力を許可しない。
-        // TODO: ログアウトしたらキャッシュをクリアしたい。むしろPlan情報は本当はSessionに入れたい。
         // TODO: Sessionに入れていない理由は、ログインとともにセッション情報がクリア（IDがリジェネリトされる）される問題を
         // 解消するのが難しいから。
         $selectPlanCookie = (int)(Cookie::get('selectPlan'));

--- a/tests/Feature/SubscriptionTest.php
+++ b/tests/Feature/SubscriptionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class SubscriptionTest extends TestCase
+{
+
+    public function test未ログインでプラン選択したらユーザー登録画面へリダイレクトする(){
+        $response = $this->post('/select',['plan' => '1000']);
+        
+        $response->assertStatus(302);
+        $response->assertRedirect('/register');
+    }
+
+    public function test全てのサブスクリプションプランが選択できる(){
+
+        $response = $this->post('/select', ['plan' => '1000']);        
+        $response->assertCookie('selectPlan', '1000');
+
+        $response = $this->post('/select', ['plan' => '3000']);
+        $response->assertCookie('selectPlan', '3000');
+
+        $response = $this->post('/select', ['plan' => '5000']);
+        $response->assertCookie('selectPlan', '5000');
+
+    }
+
+    public function test不正なサブスクリプションが選択できない(){
+
+        $response = $this->post('/select', ['plan' => '6000']);
+        
+        $response->assertCookieMissing('selectPlan');
+    }
+
+}


### PR DESCRIPTION
# 概要
サンプル用に基本的なテストケースを追加しました。
HTTPテストにしました。（単体試験よりやりやすかったです）

# 確認したこと
./vendor/phpunit/phpunit/phpunit ./tests/Feature/SubscriptionTest.php 
と実行すると
OK (3 tests, 10 assertions)
が表示されます！

# 注意点
テストケースのメソッドは先頭にtestとつける必要がありそうです。
そうしないとテストとして認識されませんでした。

例：
test未ログインでプラン選択したらユーザー登録画面へリダイレクトする
test全てのサブスクリプションプランが選択できる
test不正なサブスクリプションが選択できない

よろしくおねがいします〜！